### PR TITLE
fix(HISTFILE):change the location of history file to the backed up file

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -48,3 +48,5 @@ alias showFiles='defaults write com.apple.finder AppleShowAllFiles YES;
 alias hideFiles='defaults write com.apple.finder AppleShowAllFiles NO;
                  killall Finder /System/Library/CoreServices/Finder.app'
 export PATH="/usr/local/opt/mysql@5.5/bin:$PATH"
+
+export HISTFILE=~/dotfiles/backup_files/.zsh_history


### PR DESCRIPTION
The history file can not be symlinked and used, so instead change the
path of the history file to a location which is a git repo and can be
versioned and synced all the time.