### PR TITLE
fix(nvim):add vim_settings to be symlinked files list for nvim

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -3,7 +3,7 @@ export ZSH=/Users/shubham/.oh-my-zsh
 
 ZSH_THEME="cobalt2"
 COMPLETION_WAITING_DOTS="true"
-plugins=(git docker-rails zsh-autosuggestions short-dir zsh-completions)
+plugins=(git zsh-autosuggestions zsh-completions)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -53,8 +53,9 @@ export PATH="/usr/local/opt/mysql@5.5/bin:$PATH"
 
 export HISTFILE=~/dotfiles/backup_files/.zsh_history
 
-export NVM_DIR=~/.nvm
-source ~/.nvm/nvm.sh
+export NVM_DIR="$HOME/.nvm"
+  [ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"  # This loads nvm
+  [ -s "/usr/local/opt/nvm/etc/bash_completion" ] && . "/usr/local/opt/nvm/etc/bash_completion"  # This loads nvm bash_completion
 export PATH="/usr/local/opt/openssl/bin:$PATH"
 export LDFLAGS="-L/usr/local/opt/openssl/lib"
 export CPPFLAGS="-I/usr/local/opt/openssl/include"

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -5,4 +5,3 @@ source ~/.config/nvim/plugin_settings.vim
 source ~/.config/nvim/abbrev.vim
 source ~/.config/nvim/key_mappings.vim
 source ~/.config/nvim/vim_settings.vim
-

--- a/setup.yml
+++ b/setup.yml
@@ -101,6 +101,7 @@
       - { src: key_mappings.vim, dest: key_mappings.vim }
       - { src: plugins_list.vim, dest: plugins_list.vim }
       - { src: plugin_settings.vim, dest: plugin_settings.vim }
+      - { src: vim_settings.vim, dest: vim_settings.vim }
 
   - name: Symlink the neovim colorscheme
     file:


### PR DESCRIPTION
The vim_settings was not being symlinked and vim was failing on startup,
so add that file to the list in ansible.

Also, the plugin list does not need to have custom plugins in the list
of plugins.